### PR TITLE
[ransac] Refactor ransac_ground.h

### DIFF
--- a/src/ransac_ground.h
+++ b/src/ransac_ground.h
@@ -40,54 +40,38 @@ namespace lidar_course {
 // and a normal vector to the plane.
 struct Plane
 {
-    Eigen::Vector3f base_point;
-    Eigen::Vector3f normal;
+    Eigen::Vector3f base_point {};
+    Eigen::Vector3f normal {};
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 
 // This helper function finds indices of points that are considered inliers,
-// given a plane description and a condition on distance from the plane.
-std::vector<size_t> find_inlier_indices(
+// given a plane description and a condition on signed distance from the plane.
+template<class ConditionZ>
+inline std::vector<size_t> find_inlier_indices(
     const pcl::PointCloud<pcl::PointXYZ>::Ptr& input_cloud_ptr,
     const Plane& plane,
-    std::function<bool(float)> condition_z_fn)
+    ConditionZ condition_z)
 {
-    typedef Eigen::Transform<float, 3, Eigen::Affine, Eigen::DontAlign> Transform3f;
+    // Use general form of the equation of a plane:
+    // ax + by + cz + d = 0,
+    // normal = [a, b, c]
+    auto n = plane.normal;
+    float d_coeff = -n.dot(plane.base_point);
 
-    auto base_point = plane.base_point;
-    auto normal = plane.normal;
+    float nx = n[0], ny = n[1], nz = n[2];
 
-    // Before rotation of the coordinate frame we need to relocate the point cloud to
-    // the position of base_point of the plane.
-    Transform3f world_to_ransac_base = Transform3f::Identity();
-    world_to_ransac_base.translate(-base_point);
-    auto ransac_base_cloud_ptr = std::make_shared<pcl::PointCloud<pcl::PointXYZ> >();
-    pcl::transformPointCloud(*input_cloud_ptr, *ransac_base_cloud_ptr, world_to_ransac_base);
-
-    // We are going to use a quaternion to determine the rotation transform
-    // which is required to rotate a coordinate system that plane's normal
-    // becomes aligned with Z coordinate axis.
-    auto rotate_to_plane_quat = Eigen::Quaternionf::FromTwoVectors(
-        normal,
-        Eigen::Vector3f::UnitZ()
-    ).normalized();
-
-    // Now we can create a rotation transform and align the cloud that
-    // the candidate plane matches XY plane.
-    Transform3f ransac_base_to_ransac = Transform3f::Identity();
-    ransac_base_to_ransac.rotate(rotate_to_plane_quat);
-    auto aligned_cloud_ptr = std::make_shared<pcl::PointCloud<pcl::PointXYZ> >();
-    pcl::transformPointCloud(*ransac_base_cloud_ptr, *aligned_cloud_ptr, ransac_base_to_ransac);
-
-    // Once the point cloud is transformed into the plane coordinates,
-    // We can apply a simple criterion on Z coordinate to find inliers.
+    // We can apply a simple criterion on signed distance (which is equal
+    // to z coordinate in plane coordinate system) to find inliers.
     std::vector<size_t> indices;
-    for (size_t i_point = 0; i_point < aligned_cloud_ptr->size(); i_point++)
+    for (size_t i_point = 0, end = input_cloud_ptr->size(); i_point != end; ++i_point)
     {
-        const auto& p = (*aligned_cloud_ptr)[i_point];
-        if (condition_z_fn(p.z))
+        const auto& p = (*input_cloud_ptr)[i_point];
+        float dist = nx*p.x + ny*p.y + nz*p.z + d_coeff;
+
+        if (condition_z(dist))
         {
             indices.push_back(i_point);
         }
@@ -100,7 +84,7 @@ std::vector<size_t> find_inlier_indices(
 // that lie on triplets of points randomly sampled from the cloud.
 // Among all trials the plane that is picked is the one that has the highest
 // number of inliers. Inlier points are then removed as belonging to the ground.
-auto remove_ground_ransac(
+inline auto remove_ground_ransac(
     pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud_ptr)
 {
     // Threshold for rough point dropping by Z coordinate (meters)
@@ -108,18 +92,11 @@ auto remove_ground_ransac(
     // How much to decimate the input cloud for RANSAC sampling and inlier counting
     const size_t decimation_rate = 10;
 
-    // Tolerance threshold on the distance of an inlier to the plane (meters)
-    const float ransac_tolerance = 0.1f;
-    // After the final plane is found this is the threshold below which all
-    // points are discarded as belonging to the ground.
-    const float remove_ground_threshold = 0.2f;
-
     // To reduce the number of outliers (non-ground points) we can roughly crop
     // the point cloud by Z coordinate in the range (-rough_filter_thr, rough_filter_thr).
     // Simultaneously we perform decimation of the remaining points since the full
     // point cloud is excessive for RANSAC.
-    std::mt19937::result_type decimation_seed = 41;
-    std::mt19937 rng_decimation(decimation_seed);
+    std::mt19937 rng_decimation(std::random_device {}());
     auto decimation_gen = std::bind(
         std::uniform_int_distribution<size_t>(0, decimation_rate), rng_decimation);
 
@@ -138,17 +115,25 @@ auto remove_ground_ransac(
         }
     }
 
+    // Number of probes is based on the required errors probability and
+    // expected share of plane points in cloud
+    const float required_error_prob = 0.001;
+    const float expected_plane_pts_share = 0.67;
+    const float wrong_sample_prob = 1 - std::pow(expected_plane_pts_share, 3);
+    const size_t num_iterations = std::log(required_error_prob) / std::log(wrong_sample_prob);
+
+    // Tolerance threshold on the distance of an inlier to the plane (meters)
+    const float ransac_tolerance = 0.1f;
+
     // We need a random number generator for sampling triplets of points.
-    std::mt19937::result_type sampling_seed = 42;
-    std::mt19937 sampling_rng(sampling_seed);
+    std::mt19937 sampling_rng(std::random_device {}());
     auto random_index_gen = std::bind(
         std::uniform_int_distribution<size_t>(0, filtered_ptr->size()), sampling_rng);
 
-    // Number of RANSAC trials
-    const size_t num_iterations = 25;
     // The best plane is determined by a pair of (number of inliers, plane specification)
-    typedef std::pair<size_t, Plane> BestPair;
-    auto best = std::unique_ptr<BestPair>();
+    using BestPair = std::pair<size_t, Plane>;
+    // Default value will be replaced by any kind of choosen pair
+    BestPair best {};
     for (size_t i_iter = 0; i_iter < num_iterations; i_iter++)
     {
         // Sample 3 random points.
@@ -178,51 +163,28 @@ auto remove_ground_ransac(
                 return (z >= -ransac_tolerance) && (z <= ransac_tolerance);
             });
 
-        // If new best plane is found, update the best
-        bool found_new_best = false;
-        if (best)
+        if (inlier_indices.size() > best.first)
         {
-            if (inlier_indices.size() > best->first)
-            {
-                found_new_best = true;
-            }
-        }
-        else
-        {
-            // For the first trial update anyway
-            found_new_best = true;
-        }
-
-        if (found_new_best)
-        {
-            best = std::unique_ptr<BestPair>(new BestPair{inlier_indices.size(), plane});
+            best = BestPair{inlier_indices.size(), plane};
         }
     }
+
+    // After the final plane is found this is the threshold below which all
+    // points are discarded as belonging to the ground.
+    const float remove_ground_threshold = 0.2f;
 
     // For the best plane filter out all the points that are
     // below the plane + remove_ground_threshold.
     pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_no_ground_ptr;
-    if (best)
-    {
-        cloud_no_ground_ptr = std::make_shared<pcl::PointCloud<pcl::PointXYZ> >();
-        auto inlier_indices = find_inlier_indices(input_cloud_ptr, best->second,
-            [remove_ground_threshold](float z) -> bool {
-                return z <= remove_ground_threshold;
-            });
-        std::unordered_set<size_t> inlier_set(inlier_indices.begin(), inlier_indices.end());
-        for (size_t i_point = 0; i_point < input_cloud_ptr->size(); i_point++)
-        {
-            bool extract_non_ground = true;
-            if ((inlier_set.find(i_point) == inlier_set.end()) == extract_non_ground)
-            {
-                const auto& p = (*input_cloud_ptr)[i_point];
-                cloud_no_ground_ptr->push_back(p);
-            }
-        }
-    }
-    else
-    {
-        cloud_no_ground_ptr = input_cloud_ptr;
+    cloud_no_ground_ptr = std::make_shared<pcl::PointCloud<pcl::PointXYZ> >();
+    auto cloud_no_ground_indices = find_inlier_indices(input_cloud_ptr, best.second,
+        [remove_ground_threshold](float z) -> bool {
+            return z > remove_ground_threshold;
+        });
+
+    for (auto i_no_ground : cloud_no_ground_indices) {
+        const auto& p = (*input_cloud_ptr)[i_no_ground];
+        cloud_no_ground_ptr->push_back(p);
     }
 
     return cloud_no_ground_ptr;

--- a/src/ransac_ground.h
+++ b/src/ransac_ground.h
@@ -45,10 +45,15 @@ struct Plane
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
+// Helper alias for input iterator SFINAE check
+template<typename It>
+using InputItCheck =
+    std::enable_if_t<
+    std::is_base_of<std::input_iterator_tag, typename std::iterator_traits<It>::iterator_category>::value, int>;
 
 // This helper function finds indices of points that are considered inliers,
 // given a plane description and a condition on signed distance from the plane.
-template<class InputIt, class ConditionZ>
+template<class InputIt, class ConditionZ, InputItCheck<InputIt> = 0>
 inline std::vector<size_t> find_inlier_indices(
     InputIt it, InputIt end,
     const Plane& plane,


### PR DESCRIPTION
- Refactor find_inlier_indices function:
  - Rewrite algo - replace translations with signed distances calculation.
  - Replace std::function with template argument for better inlining.
  - Use template iterators instead of fixed input container.

- Refactor remove_ground_ransac function:
  - Improve complexity: O(N * logN) -> O(N)
  - Add checks: for sample plane normal vector validity, for resulting best pair validity
  - Use std::vector instead of std::shared_ptr whenever it is possible without API change

- A few other improvements

